### PR TITLE
Update original app to solve the problems

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -7,35 +7,68 @@ namespace Moravia.Homework
 {
     public class Document
     {
-        public string Title { get; set; }
-        public string Text { get; set; }
+        public string? Title { get; set; } = string.Empty;
+        public string Text { get; set; } = string.Empty;
     }
     class Program
     {
         static void Main(string[] args)
         {
-            var sourceFileName = Path.Combine(Environment.CurrentDirectory, "..\\..\\..\\SourceFiles\\Document1.xml");
-            var targetFileName = Path.Combine(Environment.CurrentDirectory, "..\\..\\..\\TargetFiles\\Document1.json");
-        try
+            var sourceFileName = Path.Combine(Environment.CurrentDirectory, "SourceFiles\\Document1.xml");
+            var targetFileName = Path.Combine(Environment.CurrentDirectory, "TargetFiles\\Document1.json");
+
+            string input = String.Empty;
+            try
             {
-                FileStream sourceStream = File.Open(sourceFileName, FileMode.Open);
-                var reader = new StreamReader(sourceStream);
-                string input = reader.ReadToEnd();
+                if (File.Exists(sourceFileName))
+                {
+                    using (FileStream sourceStream = File.Open(sourceFileName, FileMode.Open))
+                    using (var reader = new StreamReader(sourceStream))
+                        input = reader.ReadToEnd();
+                }
+                else
+                {
+                    Console.WriteLine("No source file has been found!");
+                    return;
+                }
+
+                var xdoc = XDocument.Parse(input);
+                var doc = new Document();
+
+                if (xdoc.Root != null)
+                {
+                    if (xdoc.Root.Element("title") != null)
+                    {
+                        doc.Title = xdoc.Root.Element("title").Value;
+                    }
+
+                    if (xdoc.Root.Element("text") != null)
+                    {
+                        doc.Text = xdoc.Root.Element("text").Value;
+                    }
+                }
+                var serializedDoc = JsonConvert.SerializeObject(doc);
+
+                FileStream? targetStream;
+                if (File.Exists(targetFileName))
+                {
+                    using (targetStream = File.Open(targetFileName, FileMode.Create, FileAccess.Write))
+
+                    using (var sw = new StreamWriter(targetStream))
+                    {
+                        sw.Write(serializedDoc);
+                    }
+                }
+                else
+                {
+                    Console.WriteLine($"No target file has been found!");
+                }
             }
             catch (Exception ex)
             {
+                Console.WriteLine($"Main method has been failed with error: {ex.Message}");
                 throw new Exception(ex.Message);
             }
-            var xdoc = XDocument.Parse(input);
-            var doc = new Document
-            {
-                Title = xdoc.Root.Element("title").Value,
-                Text = xdoc.Root.Element("text").Value
-            };
-            var serializedDoc = JsonConvert.SerializeObject(doc);
-            var targetStream = File.Open(targetFileName, FileMode.Create, FileAccess.Write);
-            var sw = new StreamWriter(targetStream);
-            sw.Write(serializedDoc);
         }
     }
 }


### PR DESCRIPTION
The PR solves the following problems:

1. `Input` variable is declared inside `try` block and not available outside of it. 
2. The relative paths contains redundant directories (like `..\..\..\`), which are not needed 
3. Null reference  exception in case of missing root elements in XML file while instantiating `Document` class
4. `File.Open` method returns an `Argument null exception` in case of missing `XML` or `JSON` file
5. Missing the `StreamWriter.Close` method (sw.Close();)
